### PR TITLE
Add setup script for Fedora 31

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ cd EnhancedSessionMode
 Run the script to install and configure **XRDP**. This may take some time and you need **sudo** rights on your machine.
 
 ```bash
-# Fedora 29, 30 or 31
-eval "$(grep VERSION_ID /etc/os-release)"
-./install_esm_fedora${VERSION_ID}.sh
+# CentOS 7 or Fedora 29/30/31
+source /etc/os-release
+./install_esm_${ID}${VERSION_ID}.sh
 ```
 
 After the scripts ran successfully, shutdown your **Fedora** VM.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ cd EnhancedSessionMode
 Run the script to install and configure **XRDP**. This may take some time and you need **sudo** rights on your machine.
 
 ```bash
-# Fedora 29
-./install_esm_fedora29.sh
-
-# Fedora 30
- ./install_esm_fedora29.sh
+# Fedora 29, 30 or 31
+eval "$(grep VERSION_ID /etc/os-release)"
+./install_esm_fedora${VERSION_ID}.sh
 ```
 
 After the scripts ran successfully, shutdown your **Fedora** VM.

--- a/install_esm_fedora31.sh
+++ b/install_esm_fedora31.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Install Hyper-V Enhanced Session Mode on Fedora 30
+
+# Load the Hyper-V kernel module
+if ! [ -f "/etc/modules-load.d/hv_sock.conf" ] || [ "$(cat /etc/modules-load.d/hv_sock.conf | grep hv_sock)" = ""  ]; then
+  echo "hv_sock" | sudo tee -a /etc/modules-load.d/hv_sock.conf > /dev/null
+fi
+
+sudo dnf install -y xrdp
+sudo systemctl enable xrdp
+sudo systemctl start xrdp
+
+# Configure xrdp
+sudo sed -i "/^port=3389/c\port=vsock://-1:3389" /etc/xrdp/xrdp.ini
+sudo sed -i "/^use_vsock=.*/c\use_vsock=false" /etc/xrdp/xrdp.ini
+sudo sed -i "/^security_layer=.*/c\security_layer=rdp" /etc/xrdp/xrdp.ini
+sudo sed -i "/^crypt_level=.*/c\crypt_level=none" /etc/xrdp/xrdp.ini
+sudo sed -i "/^bitmap_compression=.*/c\bitmap_compression=false" /etc/xrdp/xrdp.ini
+sudo sed -i "/^max_bpp=.*/c\max_bpp=24" /etc/xrdp/xrdp.ini
+
+sudo sed -i "/^X11DisplayOffset=.*/c\X11DisplayOffset=0" /etc/xrdp/sesman.ini
+if [ "$(cat /etc/X11/Xwrapper.config | grep allowed_users=anybody)" = "" ]; then
+  echo "allowed_users=anybody" | sudo tee -a /etc/X11/Xwrapper.config > /dev/null
+fi
+
+


### PR DESCRIPTION
Fedora 31 can use default `xrdp` package, just need to disable `use_vsock` in `xrdp.ini`.